### PR TITLE
Update Jetson Orin examples to L4T 35.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Sample Application that uses X11 on the Jetson Platform
 
-These samples are based on L4T 32.7.1/32.7.2/35.1/35.2.1/35.3.1 and they showcase installing X11 and Gstreamer packages in a privileged container.
+These samples are based on L4T 32.7.1/32.7.2/35.1/35.2.1/35.3.1/35.4.1/35.5.0 and they showcase installing X11 and Gstreamer packages in a privileged container.
 
 Supported modules:
 
@@ -10,14 +10,16 @@ Supported modules:
 - Jetson AGX Orin
 - Jetson Xavier AGX
 - Jetson Xavier NX (both SD-CARD and eMMC variants)
+- Jetson AGX Orin Devkit
 - Jetson Orin NX in Xavier NX Devkit NVME
 - Jetson Orin Nano 8GB (SD) Devkit NVME
+- Jetson Orin Nano 4GB in Seeed J3010
 
 These examples can also be used with device types that use third-party carrier boards.
 The jetson-tx2 example targets both the Jetson TX2 and Jetson TX2 NX modules.
 Similarly, the jetson-nano container is designed for the Nano SD, Nano eMMC and the Nano 4GB Devkit, while the Xavier NX example can be used
 for both the Xavier NX SD-CARD and the Xavier NX eMMC.
-The Jetson Orin NX example can be used on any Orin NX module regardless of the carrier board.
+The Jetson Orin NX example can be used on any Orin NX module regardless of the carrier board. Same for the Orin Nano 8GB example, which can be used on the Seeed J3010.
 
 Please see the notes regarding CUDA samples installation, compiling and running. These are not installed
 by default in the Dockerfiles in order to keep the image size as low as possible.

--- a/jetson-agx-orin-devkit/Dockerfile
+++ b/jetson-agx-orin-devkit/Dockerfile
@@ -8,16 +8,16 @@ FROM balenalib/jetson-agx-orin-devkit-ubuntu:focal
 # Prevent apt-get prompting for input
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN echo "deb https://repo.download.nvidia.com/jetson/common r35.4 main" >  /etc/apt/sources.list.d/nvidia.list \
-       && echo "deb https://repo.download.nvidia.com/jetson/t234 r35.4 main" >>  /etc/apt/sources.list.d/nvidia.list \
+RUN echo "deb https://repo.download.nvidia.com/jetson/common r35.5 main" >  /etc/apt/sources.list.d/nvidia.list \
+       && echo "deb https://repo.download.nvidia.com/jetson/t234 r35.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
        && apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
        && mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
-# Download and install BSP binaries for L4T 35.4.1
+# Download and install BSP binaries for L4T 35.5.0
 RUN \
     apt-get update && apt-get install -y wget tar lbzip2 binutils xz-utils zstd && \
-    cd /tmp/ && wget https://developer.nvidia.com/downloads/embedded/l4t/r35_release_v4.1/release/jetson_linux_r35.4.1_aarch64.tbz2 && \
-    tar xf jetson_linux_r35.4.1_aarch64.tbz2 && \
+    cd /tmp/ && wget https://developer.nvidia.com/downloads/embedded/l4t/r35_release_v5.0/release/jetson_linux_r35.5.0_aarch64.tbz2 && \
+    tar xf jetson_linux_r35.5.0_aarch64.tbz2 && \
     cd Linux_for_Tegra && \
     sed -i 's/config.tbz2\"/config.tbz2\" --exclude=etc\/hosts --exclude=etc\/hostname/g' apply_binaries.sh && \
     sed -i 's/install --owner=root --group=root \"${QEMU_BIN}\" \"${L4T_ROOTFS_DIR}\/usr\/bin\/\"/#install --owner=root --group=root \"${QEMU_BIN}\" \"${L4T_ROOTFS_DIR}\/usr\/bin\/\"/g' nv_tegra/nv-apply-debs.sh && \

--- a/jetson-orin-nano-devkit-nvme/Dockerfile
+++ b/jetson-orin-nano-devkit-nvme/Dockerfile
@@ -8,16 +8,16 @@ FROM balenalib/jetson-agx-orin-devkit-ubuntu:focal
 # Prevent apt-get prompting for input
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN echo "deb https://repo.download.nvidia.com/jetson/common r35.4 main" >  /etc/apt/sources.list.d/nvidia.list \
-       && echo "deb https://repo.download.nvidia.com/jetson/t234 r35.4 main" >>  /etc/apt/sources.list.d/nvidia.list \
+RUN echo "deb https://repo.download.nvidia.com/jetson/common r35.5 main" >  /etc/apt/sources.list.d/nvidia.list \
+       && echo "deb https://repo.download.nvidia.com/jetson/t234 r35.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
        && apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
        && mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
-# Download and install BSP binaries for L4T 35.4.1
+# Download and install BSP binaries for L4T 35.5.5
 RUN \
     apt-get update && apt-get install -y wget tar lbzip2 binutils xz-utils zstd && \
-    cd /tmp/ && wget https://developer.nvidia.com/downloads/embedded/l4t/r35_release_v4.1/release/jetson_linux_r35.4.1_aarch64.tbz2 && \
-    tar xf jetson_linux_r35.4.1_aarch64.tbz2 && \
+    cd /tmp/ && wget https://developer.nvidia.com/downloads/embedded/l4t/r35_release_v5.0/release/jetson_linux_r35.5.0_aarch64.tbz2 && \
+    tar xf jetson_linux_r35.5.0_aarch64.tbz2 && \
     cd Linux_for_Tegra && \
     sed -i 's/config.tbz2\"/config.tbz2\" --exclude=etc\/hosts --exclude=etc\/hostname/g' apply_binaries.sh && \
     sed -i 's/install --owner=root --group=root \"${QEMU_BIN}\" \"${L4T_ROOTFS_DIR}\/usr\/bin\/\"/#install --owner=root --group=root \"${QEMU_BIN}\" \"${L4T_ROOTFS_DIR}\/usr\/bin\/\"/g' nv_tegra/nv-apply-debs.sh && \

--- a/jetson-orin-nx-xavier-nx-devkit/Dockerfile
+++ b/jetson-orin-nx-xavier-nx-devkit/Dockerfile
@@ -8,16 +8,16 @@ FROM balenalib/jetson-agx-orin-devkit-ubuntu:focal
 # Prevent apt-get prompting for input
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN echo "deb https://repo.download.nvidia.com/jetson/common r35.4 main" >  /etc/apt/sources.list.d/nvidia.list \
-       && echo "deb https://repo.download.nvidia.com/jetson/t234 r35.4 main" >>  /etc/apt/sources.list.d/nvidia.list \
+RUN echo "deb https://repo.download.nvidia.com/jetson/common r35.5 main" >  /etc/apt/sources.list.d/nvidia.list \
+       && echo "deb https://repo.download.nvidia.com/jetson/t234 r35.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
        && apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
        && mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
-# Download and install BSP binaries for L4T 35.4.1
+# Download and install BSP binaries for L4T 35.5.0
 RUN \
     apt-get update && apt-get install -y wget tar lbzip2 binutils xz-utils zstd && \
-    cd /tmp/ && wget https://developer.nvidia.com/downloads/embedded/l4t/r35_release_v4.1/release/jetson_linux_r35.4.1_aarch64.tbz2 && \
-    tar xf jetson_linux_r35.4.1_aarch64.tbz2 && \
+    cd /tmp/ && wget https://developer.nvidia.com/downloads/embedded/l4t/r35_release_v5.0/release/jetson_linux_r35.5.0_aarch64.tbz2 && \
+    tar xf jetson_linux_r35.5.0_aarch64.tbz2 && \
     cd Linux_for_Tegra && \
     sed -i 's/config.tbz2\"/config.tbz2\" --exclude=etc\/hosts --exclude=etc\/hostname/g' apply_binaries.sh && \
     sed -i 's/install --owner=root --group=root \"${QEMU_BIN}\" \"${L4T_ROOTFS_DIR}\/usr\/bin\/\"/#install --owner=root --group=root \"${QEMU_BIN}\" \"${L4T_ROOTFS_DIR}\/usr\/bin\/\"/g' nv_tegra/nv-apply-debs.sh && \


### PR DESCRIPTION
OS images running L4T 35.5.0 are available starting with balenaOS v5.3.10+rev1 for AGX Orin 32GB, Orin NX, and Orin Nano modules.

Changelog-entry: Update Jetson Orin examples to L4T 35.5.0