### PR TITLE
Jetson Orin: Update CUDA installation example

### DIFF
--- a/jetson-agx-orin-devkit/Dockerfile
+++ b/jetson-agx-orin-devkit/Dockerfile
@@ -63,7 +63,7 @@ RUN echo "#!/bin/bash" > /etc/X11/xinit/xserverrc \
 #   && ldconfig
 
 ## Optional: Sample CUDA Clock sample run in webterminal:
-##  apt-get update && apt-get install -y nvidia-l4t-cuda nvidia-cuda build-essential cuda-nvcc-12-2 && git clone https://github.com/NVIDIA/cuda-samples.git && cd cuda-samples/Samples/1_Utilities/deviceQuery && make && ./deviceQuery
+##  apt-get update && apt-get install -y -o Dpkg::Options::="--force-confdef" nvidia-l4t-cuda nvidia-cuda build-essential cuda-nvcc-12-2 && git clone https://github.com/NVIDIA/cuda-samples.git && cd cuda-samples/Samples/1_Utilities/deviceQuery && make && ./deviceQuery
 ##  Example Output:
 ##
 ##./deviceQuery Starting...

--- a/jetson-orin-nano-devkit-nvme/Dockerfile
+++ b/jetson-orin-nano-devkit-nvme/Dockerfile
@@ -63,7 +63,7 @@ RUN echo "#!/bin/bash" > /etc/X11/xinit/xserverrc \
 #   && ldconfig
 
 ## Optional: Sample CUDA Clock sample run in webterminal:
-##  apt-get update && apt-get install -y nvidia-l4t-cuda nvidia-cuda build-essential cuda-nvcc-12-2 && git clone https://github.com/NVIDIA/cuda-samples.git && cd cuda-samples/Samples/1_Utilities/deviceQuery && make && ./deviceQuery
+##  apt-get update && apt-get install -y -o Dpkg::Options::="--force-confdef" nvidia-l4t-cuda nvidia-cuda build-essential cuda-nvcc-12-2 && git clone https://github.com/NVIDIA/cuda-samples.git && cd cuda-samples/Samples/1_Utilities/deviceQuery && make && ./deviceQuery
 ##  Example Output:
 ##
 ##./deviceQuery Starting...

--- a/jetson-orin-nx-xavier-nx-devkit/Dockerfile
+++ b/jetson-orin-nx-xavier-nx-devkit/Dockerfile
@@ -63,7 +63,7 @@ RUN echo "#!/bin/bash" > /etc/X11/xinit/xserverrc \
 #   && ldconfig
 
 ## Optional: Sample CUDA Clock sample run in webterminal:
-##  apt-get update && apt-get install -y nvidia-l4t-cuda nvidia-cuda build-essential cuda-nvcc-12-2 && git clone https://github.com/NVIDIA/cuda-samples.git && cd cuda-samples/Samples/1_Utilities/deviceQuery && make && ./deviceQuery
+##  apt-get update && apt-get install -y -o Dpkg::Options::="--force-confdef" nvidia-l4t-cuda nvidia-cuda build-essential cuda-nvcc-12-2 && git clone https://github.com/NVIDIA/cuda-samples.git && cd cuda-samples/Samples/1_Utilities/deviceQuery && make && ./deviceQuery
 ##  Example Output:
 ##
 ##./deviceQuery Starting...


### PR DESCRIPTION
... to allow for installing packages without
prompting during docker builds.

Re-mounting / and /lib/firmware is necessary
if cuda is being installed manually from a container, but is not needed during docker builds.

Change-type: patch