### PR TITLE
Update startxfce.sh

### DIFF
--- a/jetson-orin/startxfce.sh
+++ b/jetson-orin/startxfce.sh
@@ -8,8 +8,11 @@ DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket \
   --dest=org.freedesktop.systemd1 \
   /org/freedesktop/systemd1 \
   org.freedesktop.systemd1.Manager.StopUnit \
-  string:plymouth-quit.service string:replace
+  string:plymouth-start.service string:replace
 
+# Give some time for plymouth to stop
+sleep 2
+ 
 # Prevent "Server is already active for display 0" error,
 # in case X was forcedly closed before
 rm -rf /tmp/.X0-lock* || true
@@ -17,6 +20,8 @@ rm -rf /tmp/.X0-lock* || true
 # Prevent black screen with cursor only
 rm -rf /root/.config/ || true
 
+# Reload nvidia drm modules to drop any
+# configuration plymouth may have used
 modules=("tegra_drm" "nvidia_drm" "nvidia_modeset"); for module in "${modules[@]}";
 do
     if lsmod | grep -q ${module} ; then
@@ -24,10 +29,13 @@ do
     fi;
 done;
 
-startxfce4 & sleep 5;
-
 modprobe tegra_drm;
 modprobe nvidia_drm;
+
+sleep 1
+
+startxfce4
+
 while [ 1 ]; do
    sleep 10;
 done;


### PR DESCRIPTION
In this configuration we use dbus to stop the plymouth-start service and start xfce with the drm modules loaded

Change-type: patch