### PR TITLE
Jetson Orin: Update BSP to L4T 36.4.4

### DIFF
--- a/jetson-orin-gstreamer/Dockerfile
+++ b/jetson-orin-gstreamer/Dockerfile
@@ -28,8 +28,8 @@ RUN echo "deb https://repo.download.nvidia.com/jetson/common r36.4 main" >  /etc
 # Download and install BSP binaries for L4T 36.4.3 - Jetpack 6.2
 RUN \
     apt-get update && apt-get install -y wget tar lbzip2 binutils xz-utils zstd qemu-user-static cpio git && \
-    cd /tmp/ && wget https://developer.nvidia.com/downloads/embedded/l4t/r36_release_v4.3/release/Jetson_Linux_r36.4.3_aarch64.tbz2 && \
-    tar xf Jetson_Linux_r36.4.3_aarch64.tbz2 && \
+    cd /tmp/ && wget https://developer.nvidia.com/downloads/embedded/l4t/r36_release_v4.4/release/Jetson_Linux_r36.4.4_aarch64.tbz2 && \
+    tar xf Jetson_Linux_r36.4.4_aarch64.tbz2 && \
     cd Linux_for_Tegra && \
     mkdir -p /tmp/Linux_for_Tegra/rootfs/boot/ && \
     mkdir -p /tmp/Linux_for_Tegra/rootfs/usr/bin && \

--- a/jetson-orin/Dockerfile
+++ b/jetson-orin/Dockerfile
@@ -23,11 +23,11 @@ RUN echo "deb https://repo.download.nvidia.com/jetson/common r36.4 main" >  /etc
        && apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
        && mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
-# Download and install BSP binaries for L4T 36.4.3 - Jetpack 6.2
+# Download and install BSP binaries for L4T 36.4.4 - Jetpack 6.2.1
 RUN \
     apt-get update && apt-get install -y wget tar lbzip2 binutils xz-utils zstd qemu-user-static cpio git && \
-    cd /tmp/ && wget https://developer.nvidia.com/downloads/embedded/l4t/r36_release_v4.3/release/Jetson_Linux_r36.4.3_aarch64.tbz2 && \
-    tar xf Jetson_Linux_r36.4.3_aarch64.tbz2 && \
+    cd /tmp/ && wget https://developer.nvidia.com/downloads/embedded/l4t/r36_release_v4.4/release/Jetson_Linux_r36.4.4_aarch64.tbz2 && \
+    tar xf Jetson_Linux_r36.4.4_aarch64.tbz2 && \
     cd Linux_for_Tegra && \
     mkdir -p /tmp/Linux_for_Tegra/rootfs/boot/ && \
     mkdir -p /tmp/Linux_for_Tegra/rootfs/usr/bin && \


### PR DESCRIPTION
This can be used with balenaOS v6.12.3 and newer

Change-type: patch